### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,16 @@ on:
 
 jobs:
   test:
-    name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }} on ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-
+    name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }})
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - elixir: '1.18.4'
             otp: '28.0'
-            os: ubuntu-latest
-          - elixir: '1.7.0'
-            otp: '22.0'
-            os: windows-2022
-
+          - elixir: '1.12.0'
+            otp: '24.0'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             otp: '28.0'
             os: ubuntu-latest
           - elixir: '1.7.0'
-            otp: '21.0'
+            otp: '22.0'
             os: windows-2022
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,21 @@ on:
       - dev
 
 jobs:
-  test-latest:
-    name: Test (v1.18.4, OTP-28)
-    runs-on: ubuntu-latest
+  test:
+    name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: '1.18.4'
+            otp: '28.0'
+            os: ubuntu-latest
+          - elixir: '1.7.0'
+            otp: '21.0'
+            os: windows-2022
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -17,27 +29,9 @@ jobs:
       - name: Setup Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.18.4'
-          otp-version: '28.0'
-
-      - name: Install Dependencies
-        run: mix deps.get
-
-      - name: Run Tests
-        run: mix test
-
-  test-oldest:
-    name: Test (v1.7.0, OTP-21)
-    runs-on: windows-2022
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          elixir-version: '1.7.0'
-          otp-version: '21.0'
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+          version-type: 'strict'
 
       - name: Install Dependencies
         run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,9 @@ on:
       - dev
 
 jobs:
-  test:
-    name: Test
+  test-latest:
+    name: Test (v1.18.4, OTP-28)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - elixir: '1.7.0'
-            otp: '21.0'
-
-          - elixir: '1.18.4'
-            otp: '28.0'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -26,8 +17,27 @@ jobs:
       - name: Setup Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+          elixir-version: '1.18.4'
+          otp-version: '28.0'
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Run Tests
+        run: mix test
+
+  test-oldest:
+    name: Test (v1.7.0, OTP-21)
+    runs-on: windows-2022
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.7.0'
+          otp-version: '21.0'
 
       - name: Install Dependencies
         run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Elixir CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: '1.7.0'
+            otp: '21.0'
+
+          - elixir: '1.18.4'
+            otp: '28.0'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Run Tests
+        run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
         include:
           - elixir: '1.18.4'
             otp: '28.0'
+            version-type: 'strict'
           - elixir: '1.12.0'
-            otp: '24.3'
+            otp: '24.x'
+            version-type: 'loose'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -27,7 +29,7 @@ jobs:
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
-          version-type: 'strict'
+          version-type: ${{ matrix.version-type }}
 
       - name: Install Dependencies
         run: mix deps.get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - elixir: '1.18.4'
             otp: '28.0'
           - elixir: '1.12.0'
-            otp: '24.0'
+            otp: '24.3'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added CI workflow to run tests against supported Elixir versions
+
+### Changed
+
+- Updated minimum supported Elixir version to v1.12
+  - While the library may work with older versions, StreamData supports a
+    minimum of v1.12, so it would be missing the property tests
+
+### Fixed
+
+- Updated timestamp decoding to be backwards-compatible with Elixir v1.12
+
 ## [v1.0.2] - 2025-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ This section explains how to setup the project locally for development.
 ### Dependencies
 
 - Elixir `~> 1.12` (OTP 24+)
+  - See [Compatibility and
+    deprecations](https://hexdocs.pm/elixir/1.18.4/compatibility-and-deprecations.html)
+    for more information
 
 ### Get the Source
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This section explains how to setup the project locally for development.
 
 ### Dependencies
 
-- Elixir `~> 1.7` (OTP 21+)
+- Elixir `~> 1.12` (OTP 24+)
 
 ### Get the Source
 

--- a/lib/msgpack/decoder.ex
+++ b/lib/msgpack/decoder.ex
@@ -233,7 +233,9 @@ defmodule Msgpack.Decoder do
       base_datetime = NaiveDateTime.from_erl!(erlang_datetime)
 
       if nanoseconds > 0 do
-        NaiveDateTime.add(base_datetime, nanoseconds, :nanosecond)
+        # NaiveDateTime.add(base_datetime, nanoseconds, :nanosecond)
+        microseconds = div(nanoseconds, 1000)
+        %{base_datetime | microsecond: {microseconds, 6}}
       else
         base_datetime
       end
@@ -250,7 +252,9 @@ defmodule Msgpack.Decoder do
       base_datetime = NaiveDateTime.from_erl!(erlang_datetime)
 
       if nanoseconds > 0 do
-        NaiveDateTime.add(base_datetime, nanoseconds, :nanosecond)
+        # NaiveDateTime.add(base_datetime, nanoseconds, :nanosecond)
+        microseconds = div(nanoseconds, 1000)
+        %{base_datetime | microsecond: {microseconds, 6}}
       else
         base_datetime
       end

--- a/lib/msgpack/decoder.ex
+++ b/lib/msgpack/decoder.ex
@@ -233,7 +233,6 @@ defmodule Msgpack.Decoder do
       base_datetime = NaiveDateTime.from_erl!(erlang_datetime)
 
       if nanoseconds > 0 do
-        # NaiveDateTime.add(base_datetime, nanoseconds, :nanosecond)
         microseconds = div(nanoseconds, 1000)
         %{base_datetime | microsecond: {microseconds, 6}}
       else
@@ -252,7 +251,6 @@ defmodule Msgpack.Decoder do
       base_datetime = NaiveDateTime.from_erl!(erlang_datetime)
 
       if nanoseconds > 0 do
-        # NaiveDateTime.add(base_datetime, nanoseconds, :nanosecond)
         microseconds = div(nanoseconds, 1000)
         %{base_datetime | microsecond: {microseconds, 6}}
       else

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule MsgpackElixir.MixProject do
     [
       app: :msgpack_elixir,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),


### PR DESCRIPTION
## What's changed
### Added

- Added CI workflow to run tests against supported Elixir versions

### Changed

- Updated minimum supported Elixir version to v1.12
  - While the library may work with older versions, StreamData supports a
    minimum of v1.12, so it would be missing the property tests

### Fixed

- Updated timestamp decoding to be backwards-compatible with Elixir v1.12